### PR TITLE
fix WebRTC and calls stuff

### DIFF
--- a/xows_cli.js
+++ b/xows_cli.js
@@ -970,6 +970,7 @@ function xows_cli_init()
   xows_xmp_set_callback("mucsubj",    xows_cli_muc_onsubj);
   xows_xmp_set_callback("mucnoti",    xows_cli_muc_onnoti);
   xows_xmp_set_callback("jingrecv",   xows_cli_call_jing_onrecv);
+  xows_xmp_set_callback("jmsgrecv",   xows_cli_call_jmsg_onrecv);
 
   // Set event listener to handle page quit or reload
   xows_doc_listener_add(window, "beforeunload", xows_cli_onuload);
@@ -5173,13 +5174,15 @@ function xows_cli_call_create(peer, dir, ste)
   // Create session data object
   const session =  {
     "sid" : null,   //< Jingle SID
-    "ste" : ste     //< Call session state
+    "ste" : ste,    //< Call session state
+    "jmi" : null    //< JMI media info (if session started via XEP-0353)
   };
 
   xows_def_readonly(session,"dir",dir);
   xows_def_readonly(session,"rpc",rpc);
   xows_def_readonly(session,"loc",{"pnd":false, "sdp": null, "str":null});
   xows_def_readonly(session,"rmt",{"pnd":false, "sdp": null, "str":null});
+  xows_def_readonly(session,"ice_queue",[]);  //< Queued ICE candidates before remote SDP
 
   Object.seal(session); //< prevet structure modification
 
@@ -5271,6 +5274,9 @@ function xows_cli_call_medias(peer)
               video : sess.rmt.str.getVideoTracks().length > 0 };
   } else if(sess.rmt.sdp) {
     remot = xows_sdp_get_medias(sess.rmt.sdp);
+  } else if(sess.jmi) {
+    // JMI case: use propose medias when no SDP/stream available
+    remot = { audio : sess.jmi.audio, video : sess.jmi.video };
   }
 
   let local = null;
@@ -5437,6 +5443,25 @@ function xows_cli_call_clear(peer)
 }
 
 /**
+ * Flush queued ICE candidates after remote description has been set.
+ *
+ * @param   {object}    peer    Peer object
+ */
+function xows_cli_call_ice_flush(peer)
+{
+  const sess = xows_cli_call_db.get(peer);
+  if(!sess || !sess.ice_queue.length)
+    return;
+
+  xows_log(2,"cli_call_ice_flush","Flushing",sess.ice_queue.length,"queued ICE candidates");
+  while(sess.ice_queue.length) {
+    const c = sess.ice_queue.shift();
+    sess.rpc.addIceCandidate(new RTCIceCandidate(c))
+      .catch((e) => xows_log(1,"cli_call_ice_flush","Failed:",e.message));
+  }
+}
+
+/**
  *
  * Offer (invite) the specified Peer for Media Call Session.
  *
@@ -5452,6 +5477,10 @@ function xows_cli_call_self_invite(peer, audio, video)
   // Create new (outbound) session dataset for Peer
   const sess = xows_cli_call_create(peer, XOWS_CALL_OUBD, XOWS_CALL_PEND);
 
+  // Generate session ID for JMI
+  const sid = xows_gen_nonce_asc(16);
+  sess.sid = sid;
+
   // Create new Stream object to combine audio and video tracks
   const stream = new MediaStream();
 
@@ -5464,12 +5493,33 @@ function xows_cli_call_self_invite(peer, audio, video)
       stream.addTrack(track);
   }
 
-  // Set session RPC and local stream
+  // Set session local stream (don't set on RPC yet - wait for proceed)
   sess.loc.str = stream;
 
-  // Set RTC local stream, then wait for RTC to generate a local SDP
-  // that will be passed to 'xows_cli_wrtc_onsdesc' callback
-  xows_wrtc_set_local_stream(sess.rpc, stream);
+  // Build media list for propose
+  const medias = [];
+  if(stream.getAudioTracks().length) medias.push("audio");
+  if(stream.getVideoTracks().length) medias.push("video");
+
+  // Store JMI info
+  sess.jmi = {audio: medias.includes("audio"), video: medias.includes("video")};
+
+  // Send JMI propose to peer's bare JID
+  xows_log(2,"cli_call_invite","Sending JMI propose to",peer.addr);
+  xows_xmp_jmsg_propose_send(peer.jbar, sid, medias);
+
+  // Fallback: if no JMI response (ringing/proceed) within 10s,
+  // fall back to direct session-initiate for non-JMI clients
+  setTimeout(() => {
+    if(xows_cli_call_db.has(peer)) {
+      const s = xows_cli_call_db.get(peer);
+      if(s.sid === sid && s.ste === XOWS_CALL_PEND && !s.loc.sdp) {
+        xows_log(1,"cli_call_invite","No JMI response, falling back to direct session-initiate");
+        // Initiate RTC directly
+        xows_wrtc_set_local_stream(s.rpc, s.loc.str);
+      }
+    }
+  }, 10000);
 }
 
 /**
@@ -5507,6 +5557,13 @@ function xows_cli_call_self_accept(peer, audio, video)
   // Set session local stream
   sess.loc.str = stream;
 
+  // JMI case: no remote SDP yet, send <proceed> and wait for session-initiate
+  if(sess.jmi && !sess.rmt.sdp) {
+    xows_log(2,"cli_call_accept","JMI: sending proceed for",peer.addr);
+    xows_xmp_jmsg_proceed_send(peer.jrpc, sess.sid);
+    return;
+  }
+
   // Set RTC remote SDP, then wait for RTC to generate remote Stream
   // that will be passed to 'xows_cli_wrtc_ontrack' callback
   xows_wrtc_set_local_stream(sess.rpc, stream);
@@ -5538,7 +5595,15 @@ function xows_cli_call_self_hangup(peer, reason)
   // Send Jingle session terminate
   if(sess.sid) {
     if(!reason) reason = "success";
-    xows_xmp_jing_terminate(peer.jrpc, sess.sid, reason);
+    if(sess.jmi && !sess.loc.sdp && sess.dir === XOWS_CALL_OUBD) {
+      // JMI outbound: no SDP created yet, retract the proposal
+      xows_xmp_jmsg_retract_send(peer.jbar, sess.sid);
+    } else if(sess.jmi && !sess.rmt.sdp && sess.dir === XOWS_CALL_INBD) {
+      // JMI inbound: no session-initiate received yet, send JMI reject
+      xows_xmp_jmsg_reject_send(peer.jrpc, sess.sid);
+    } else {
+      xows_xmp_jing_terminate(peer.jrpc, sess.sid, reason);
+    }
   }
 
   // Clear call session
@@ -5577,6 +5642,9 @@ function xows_cli_call_peer_invite(peer, from, sid, sdp)
   // Set RTC remote SDP, then wait for RTC to generate remote Stream
   // that will be passed to 'xows_cli_wrtc_ontrack' callback
   xows_wrtc_set_remote_sdp(sess.rpc, sdp);
+
+  // Flush any queued ICE candidates
+  xows_cli_call_ice_flush(peer);
 }
 
 /**
@@ -5599,6 +5667,9 @@ function xows_cli_call_peer_accept(peer, sdp)
   // Set RTC remote SDP, then wait for RTC to generate remote Stream
   // that will be passed to 'xows_cli_wrtc_ontrack' callback
   xows_wrtc_set_remote_sdp(sess.rpc, sdp);
+
+  // Flush any queued ICE candidates
+  xows_cli_call_ice_flush(peer);
 }
 
 /**
@@ -5712,8 +5783,18 @@ function xows_cli_call_jing_onrecv(from, id, sid, action, data)
   switch(action)
   {
   case "session-initiate": {
-      // Handle received call Offer
-      xows_cli_call_peer_invite(peer, from, sid, data);
+      if(sess && sess.dir === XOWS_CALL_INBD && sess.jmi) {
+        // JMI: session already exists from propose, update with SDP
+        xows_log(2,"cli_xmp_onjingle","JMI session-initiate from",from);
+        peer.jrpc = from;
+        sess.rmt.sdp = data;
+        xows_wrtc_set_remote_sdp(sess.rpc, data);
+        // Flush any queued ICE candidates
+        xows_cli_call_ice_flush(peer);
+      } else {
+        // Direct session-initiate: create new session
+        xows_cli_call_peer_invite(peer, from, sid, data);
+      }
     } break;
 
   case "session-accept": {
@@ -5748,6 +5829,26 @@ function xows_cli_call_jing_onrecv(from, id, sid, action, data)
       xows_cli_call_peer_hangup(peer, data);
     } break;
 
+  case "transport-info": {
+      // Add trickle ICE candidates to RTC connection
+      if(data && data.length) {
+        if(sess.rpc.remoteDescription) {
+          // Remote description is set, add candidates directly
+          for(let i = 0; i < data.length; ++i) {
+            const iceCandidate = new RTCIceCandidate(data[i]);
+            sess.rpc.addIceCandidate(iceCandidate)
+              .then(() => xows_log(2,"cli_xmp_onjingle","Added ICE candidate from",from))
+              .catch((e) => xows_log(1,"cli_xmp_onjingle","Failed to add ICE candidate:",e.message));
+          }
+        } else {
+          // Queue candidates until remote description is set
+          xows_log(2,"cli_xmp_onjingle","Queueing ICE candidate (no remote SDP yet)");
+          for(let i = 0; i < data.length; ++i)
+            sess.ice_queue.push(data[i]);
+        }
+      }
+    } break;
+
   default:
     xows_xmp_iq_error_send(id, from, "cancel", "bad-request"); //< Send back iq error
     break;
@@ -5755,6 +5856,149 @@ function xows_cli_call_jing_onrecv(from, id, sid, action, data)
 
   // Acknoledge reception (send back "result" type iq)
   xows_xmp_iq_result_send(id, from);
+}
+
+/* ---------------------------------------------------------------------------
+ * Media Call Sessions - Jingle Message Initiation (XEP-0353)
+ * ---------------------------------------------------------------------------*/
+/**
+ * Handles received Jingle Message Initiation (XEP-0353) signaling
+ * (forwarded from XMPP Module)
+ *
+ * @param   {string}    from      Sender JID
+ * @param   {string}    action    JMI action (propose, proceed, retract, reject, accept, ringing)
+ * @param   {string}    sid       Session ID
+ * @param   {string[]}  medias    Array of media type strings
+ */
+function xows_cli_call_jmsg_onrecv(from, action, sid, medias)
+{
+  xows_log(2,"cli_jmsg_onrecv","received",action,"sid="+sid);
+
+  // Retreive related Peer
+  const peer = xows_cli_peer_get(from, XOWS_PEER_ANY);
+  if(!peer) {
+    xows_log(1,"cli_jmsg_onrecv","unknown peer",from);
+    return;
+  }
+
+  // Ignore messages from self (carbon copies of our own JMI)
+  if(peer.self) {
+    xows_log(2,"cli_jmsg_onrecv","ignoring self carbon copy");
+    return;
+  }
+
+  switch(action)
+  {
+  case "propose": {
+      // Check if already in a call
+      if(xows_cli_call_buzy()) {
+        xows_log(2,"cli_jmsg_onrecv","busy, rejecting propose from",from);
+        xows_xmp_jmsg_reject_send(from, sid);
+        return;
+      }
+
+      // Set Peer's Jingle resource JID
+      peer.jrpc = from;
+
+      if(peer.type === XOWS_PEER_OCCU) {
+        if(xows_cli_ocpm_add(peer))
+          xows_cli_fw_occupush(peer);
+      }
+
+      // Parse media types from propose
+      const jmi = {audio: false, video: false};
+      for(let i = 0; i < medias.length; ++i) {
+        if(medias[i] === "audio") jmi.audio = true;
+        if(medias[i] === "video") jmi.video = true;
+      }
+
+      // Create new (inbound) session dataset for Peer
+      const sess = xows_cli_call_create(peer, XOWS_CALL_INBD, XOWS_CALL_RING);
+      sess.sid = sid;
+      sess.jmi = jmi;
+
+      // Send ringing notification back to caller
+      xows_xmp_jmsg_ringing_send(from, sid);
+
+      // Forward as incoming call offer (null stream, JMI)
+      xows_cli_fw_calloffer(peer, null);
+    } break;
+
+  case "retract": {
+      if(!xows_cli_call_db.has(peer))
+        return;
+      const sess = xows_cli_call_db.get(peer);
+      if(sess.sid !== sid)
+        return;
+      // Caller retracted the call
+      xows_cli_call_peer_hangup(peer, "success");
+    } break;
+
+  case "accept": {
+      // Another device of same account accepted the call
+      if(!xows_cli_call_db.has(peer))
+        return;
+      const sess = xows_cli_call_db.get(peer);
+      if(sess.sid !== sid)
+        return;
+      // Dismiss ringing - call was picked up elsewhere
+      xows_cli_call_peer_hangup(peer, "success");
+    } break;
+
+  case "finish": {
+      // Call finished (sent by some clients after session-terminate)
+      if(!xows_cli_call_db.has(peer))
+        return;
+      const sess = xows_cli_call_db.get(peer);
+      if(sess.sid !== sid)
+        return;
+      xows_cli_call_peer_hangup(peer, "success");
+    } break;
+
+  case "proceed": {
+      // Peer accepted to proceed - now initiate the actual Jingle session
+      xows_log(2,"cli_jmsg_onrecv","proceed from",from,"sid="+sid);
+      if(!xows_cli_call_db.has(peer)) {
+        xows_log(1,"cli_jmsg_onrecv","proceed: no session for peer",peer.addr);
+        return;
+      }
+      const sess = xows_cli_call_db.get(peer);
+      xows_log(2,"cli_jmsg_onrecv","proceed: sess.sid="+sess.sid,"dir="+sess.dir,"has loc.str="+!!sess.loc.str);
+      if(sess.sid !== sid || sess.dir !== XOWS_CALL_OUBD)
+        return;
+
+      // Update peer JID to the full JID that sent proceed
+      peer.jrpc = from;
+
+      xows_log(2,"cli_jmsg_onrecv","Peer proceeded, initiating RTC for",peer.addr);
+
+      // Now set local stream on RPC to trigger SDP offer creation
+      xows_wrtc_set_local_stream(sess.rpc, sess.loc.str);
+    } break;
+
+  case "reject": {
+      // Peer rejected the proposal
+      if(!xows_cli_call_db.has(peer))
+        return;
+      const sess = xows_cli_call_db.get(peer);
+      if(sess.sid !== sid || sess.dir !== XOWS_CALL_OUBD)
+        return;
+
+      xows_log(2,"cli_jmsg_onrecv","Peer rejected proposal",peer.addr);
+      xows_cli_call_peer_hangup(peer, "decline");
+    } break;
+
+  case "ringing": {
+      // Peer is ringing
+      if(!xows_cli_call_db.has(peer))
+        return;
+      const sess = xows_cli_call_db.get(peer);
+      if(sess.sid !== sid || sess.dir !== XOWS_CALL_OUBD)
+        return;
+      // Forward ringing state to GUI
+      xows_cli_fw_callstate(peer, "ringing");
+    } break;
+  }
 }
 
 /* ---------------------------------------------------------------------------
@@ -5791,7 +6035,19 @@ function xows_cli_wrtc_onsdesc(rpc, sdp, peer)
 
     // Send SDP offer via Jingle, then wait for remote peer Jingle
     // answer, either with session-accept or session-terminate.
-    sess.sid = xows_xmp_jing_initiate_sdp(peer.jrpc, sdp, xows_cli_call_jing_parse);
+    // Reuse existing SID (from JMI propose) if available
+    sess.sid = xows_xmp_jing_initiate_sdp(peer.jrpc, sdp, xows_cli_call_jing_parse, sess.sid);
+
+    // Set a timeout: if peer doesn't respond within 30s, terminate
+    setTimeout(() => {
+      if(xows_cli_call_db.has(peer)) {
+        const s = xows_cli_call_db.get(peer);
+        if(s.sid === sess.sid && s.ste === XOWS_CALL_PEND) {
+          xows_log(1,"cli_wrtc_onsdesc","Call timeout, no answer from",peer.addr);
+          xows_cli_call_peer_hangup(peer, "timeout");
+        }
+      }
+    }, 30000);
   }
 }
 
@@ -5812,13 +6068,26 @@ function xows_cli_wrtc_ontrack(rpc, stream, peer)
   sess.rmt.str = stream;
 
   if(sess.dir === XOWS_CALL_INBD) {
-    xows_log(2,"cli_wrtc_ontrack","Received offer stream from",peer.addr);
 
-    // Send "ringing" session info to Peer
-    xows_xmp_jing_info(peer.jrpc, sess.sid, "ringing", xows_cli_call_jing_parse);
+    if(sess.jmi && sess.loc.str && !sess.loc.pnd) {
+      // JMI pre-accepted: user already accepted, set local stream now
+      sess.loc.pnd = true; // Prevent repeated calls from per-track ontrack events
+      xows_log(2,"cli_wrtc_ontrack","JMI auto-accept for",peer.addr);
+      xows_wrtc_set_local_stream(sess.rpc, sess.loc.str);
+    }
 
-    // Stream follows remote Offer for local callee
-    xows_cli_fw_calloffer(peer, stream);
+    if(sess.jmi && sess.loc.pnd) {
+      // Forward each track arrival so GUI can update (audio → video)
+      xows_cli_fw_callanwse(peer, stream);
+    } else if(!sess.loc.pnd) {
+      xows_log(2,"cli_wrtc_ontrack","Received offer stream from",peer.addr);
+
+      // Send "ringing" session info to Peer
+      xows_xmp_jing_info(peer.jrpc, sess.sid, "ringing", xows_cli_call_jing_parse);
+
+      // Stream follows remote Offer for local callee
+      xows_cli_fw_calloffer(peer, stream);
+    }
 
   } else {
     xows_log(2,"cli_wrtc_ontrack","Received answer stream from",peer.addr);
@@ -5848,6 +6117,18 @@ function xows_cli_wrtc_onstate(rpc, state, peer)
   if(state === "connected") {
     // Set session as connected
     xows_cli_call_db.get(peer).ste = XOWS_CALL_CNTD;
+  }
+
+  if(state === "failed") {
+    // Connection truly failed - terminate the call
+    xows_cli_call_db.get(peer).ste = XOWS_CALL_HGUP;
+
+    // Forward error (as DOMException-like object for GUI compatibility)
+    xows_cli_fw_callerror(peer, true, {name: "Connection failed"});
+
+    // Hang up with peer
+    xows_cli_call_self_hangup(peer, "failed-transport");
+    return;
   }
 
   xows_cli_fw_callstate(peer, state);

--- a/xows_gui_call.js
+++ b/xows_gui_call.js
@@ -258,18 +258,27 @@ function xows_gui_call_view_part_add(peer, part, stream)
   let element;
   let media = call_grid.querySelector("[data-part='"+part.addr+"']");
   if(media) {
-    // Simply update stream
-    media.srcObject = stream;
-    return;
-  } else {
-    // Create <strm-audio> or <strm-video> element from template
-    if(is_video) {
-      element = xows_tpl_spawn_stream_video(part);
-      media = element.querySelector("video");
+    // Check if we need to upgrade from audio to video element
+    const was_video = (media.tagName === "VIDEO");
+    if(is_video && !was_video) {
+      // Remove old audio element and its parent wrapper
+      const old_element = media.closest("strm-audio");
+      if(old_element) old_element.remove();
+      // Fall through to create new video element
     } else {
-      element = xows_tpl_spawn_stream_audio(part);
-      media = element.querySelector("audio");
+      // Simply update stream
+      media.srcObject = stream;
+      return;
     }
+  }
+
+  // Create <strm-audio> or <strm-video> element from template
+  if(is_video) {
+    element = xows_tpl_spawn_stream_video(part);
+    media = element.querySelector("video");
+  } else {
+    element = xows_tpl_spawn_stream_audio(part);
+    media = element.querySelector("audio");
   }
 
   // Mute audio output since it will be managed through AudioContext
@@ -277,9 +286,11 @@ function xows_gui_call_view_part_add(peer, part, stream)
 
   // Set stream to Media element
   if(!part.self) {
-    // Plug media element to 'master' output
-    xows_snd_outpt_new(peer, stream);
-    xows_snd_outpt_gain_set(peer, parseInt(xows_gui_doc(peer,"call_volu").value) / 100);
+    // Plug media element to 'master' output (only if stream has audio)
+    if(stream.getAudioTracks().length) {
+      xows_snd_outpt_new(peer, stream);
+      xows_snd_outpt_gain_set(peer, parseInt(xows_gui_doc(peer,"call_volu").value) / 100);
+    }
     media.srcObject = stream;
     media.autoplay = true;
   } else {
@@ -405,6 +416,10 @@ function xows_gui_hist_ring_show(peer, type, reason)
       case "unsupported-applications":
       case "unsupported-transports":
         text = "The other party encountered error";
+        break;
+
+      case "timeout":
+        text = "No answer from the other party";
         break;
 
       default:
@@ -703,8 +718,11 @@ function xows_gui_call_self_hangup(peer, reason)
  */
 function xows_gui_call_onoffer(peer, stream)
 {
-  // Add remote participant to Call View
-  xows_gui_call_view_part_add(peer, peer, stream);
+  // Add remote participant to Call View (if stream is available;
+  // for JMI propose, stream is null until session-initiate arrives)
+  if(stream) {
+    xows_gui_call_view_part_add(peer, peer, stream);
+  }
 
   // If peer is offscreen during incomming call, add notification
   if(peer !== xows_gui_peer)

--- a/xows_wrtc.js
+++ b/xows_wrtc.js
@@ -56,7 +56,8 @@ function xows_wrtc_gen_credential(name, secret)
 {
   const expire = parseInt(Date.now()/1000) + 24*3600;
   const username = expire+":"+name;
-  const password = xows_bytes_to_b64(xows_hmac_sha1(username, secret));
+  // TURN REST API: password = base64(HMAC-SHA1(secret, username))
+  const password = xows_bytes_to_b64(xows_hmac_sha1(secret, username));
 
   return {"username":username,"password":password};
 }
@@ -110,6 +111,16 @@ function xows_wrtc_onneednego(event)
 
   // Request to create an SDP Offer
   rpc.createOffer().then((rsd) => rpc.setLocalDescription(rsd))
+                   .then(() => {
+                      // Set a fallback timeout: if ICE gathering doesn't
+                      // complete within 5s, send the SDP with what we have.
+                      setTimeout(() => {
+                        if(rpc.iceGatheringState !== "complete") {
+                          xows_log(1,"wrtc_onneednego","ICE gathering timeout, forcing SDP delivery");
+                          xows_wrtc_sdp_deliver(rpc);
+                        }
+                      }, 5000);
+                   })
                    .then(null, (err) => xows_wrtc_onerror(rpc, err));
 }
 
@@ -132,29 +143,72 @@ function xows_wrtc_onicestate(event)
     db.onstate(rpc, rpc.iceGatheringState, db.param);
 
   if(rpc.iceGatheringState === "complete") {
-    // Forward generated local SDP
-    if(xows_isfunc(db.onsdesc))
-      db.onsdesc(rpc, rpc.localDescription.sdp, db.param);
+    xows_wrtc_sdp_deliver(rpc);
   }
+}
+
+/**
+ * Handles WebRTC Peer Connection ICE candidate event.
+ *
+ * When event.candidate is null, ICE gathering is complete. This is a
+ * more reliable signal than onicegatheringstatechange in some browsers.
+ *
+ * @param   {object}      event    RTCPeerConnectionIceEvent object
+ */
+function xows_wrtc_onicecandidate(event)
+{
+  const rpc = event.target;
+
+  if(event.candidate) {
+    xows_log(2,"wrtc_onicecandidate","ICE candidate:",event.candidate.type,event.candidate.protocol,event.candidate.address);
+  } else {
+    xows_log(2,"wrtc_onicecandidate","ICE gathering finished (null candidate)");
+    xows_wrtc_sdp_deliver(rpc);
+  }
+}
+
+/**
+ * Delivers local SDP description to the callback, guarding against
+ * duplicate delivery.
+ *
+ * @param   {object}      rpc       Instance of RTCPeerConnection object
+ */
+function xows_wrtc_sdp_deliver(rpc)
+{
+  const db = xows_wrtc_db.get(rpc);
+  if(!db || db.sdp_sent)
+    return;
+
+  if(!rpc.localDescription || !rpc.localDescription.sdp)
+    return;
+
+  db.sdp_sent = true;
+
+  xows_log(2,"wrtc_sdp_deliver","Forwarding local SDP");
+
+  // Forward generated local SDP
+  if(xows_isfunc(db.onsdesc))
+    db.onsdesc(rpc, rpc.localDescription.sdp, db.param);
 }
 
 /**
  * Handles WebRTC Peer Connection ICE candidate error (forwarded from
  * RTCPeerConnection object)
  *
+ * ICE candidate errors are normal during the gathering process - they
+ * indicate that a specific STUN/TURN server or candidate path failed,
+ * not that the overall connection will fail. The actual connection
+ * failure is detected via onconnectionstatechange going to "failed".
+ *
  *@param   {object}      event    RTCPeerConnectionIceErrorEvent object
  */
 function xows_wrtc_oniceerror(event)
 {
-  const rpc = event.target;
-
-  xows_log(1,"wrtc_oniceerror",event.name);
-
-  const db = xows_wrtc_db.get(rpc);
-
-  // Forward error
-  if(xows_isfunc(db.onerror))
-    db.onerror(rpc, event, db.param);
+  // Log as warning but do NOT forward as fatal error
+  xows_log(1,"wrtc_oniceerror","ICE candidate error:"
+            ,"code=" + event.errorCode
+            ,"url=" + event.url
+            ,"text=" + event.errorText);
 }
 
 /**
@@ -218,7 +272,16 @@ function xows_wrtc_new(icelist, onsdesc, ontrack, onstate, onerror, param)
   const iceservers = [];
 
   for(let i = 0; i < icelist.length; ++i) {
-    const ice = {urls:icelist[i].type+":"+icelist[i].host+":"+icelist[i].port};
+
+    // Build proper ICE server URL
+    // STUN format: stun:host[:port]
+    // TURN format: turn:host[:port][?transport=udp|tcp]
+    let url = icelist[i].type+":"+icelist[i].host;
+    if(icelist[i].port) url += ":"+icelist[i].port;
+    if(icelist[i].transport && icelist[i].type.startsWith("turn"))
+      url += "?transport="+icelist[i].transport;
+
+    const ice = {urls:url};
     xows_log(2,"xows_wrtc_new","using ICE",ice.urls);
     // Check whether we need to generate credentials
     if(icelist[i].secret) {
@@ -239,9 +302,10 @@ function xows_wrtc_new(icelist, onsdesc, ontrack, onstate, onerror, param)
   rpc.onnegotiationneeded = xows_wrtc_onneednego;
   rpc.onconnectionstatechange = xows_wrtc_oncnxstate;
   rpc.onicegatheringstatechange = xows_wrtc_onicestate;
+  rpc.onicecandidate = xows_wrtc_onicecandidate;
   rpc.onicecandidateerror = xows_wrtc_oniceerror;
 
-  xows_wrtc_db.set(rpc,{"onerror":onerror,"onstate":onstate,"onsdesc":onsdesc,"ontrack":ontrack,"param":param});
+  xows_wrtc_db.set(rpc,{"onerror":onerror,"onstate":onstate,"onsdesc":onsdesc,"ontrack":ontrack,"param":param,"sdp_sent":false});
 
   return rpc;
 }
@@ -279,6 +343,15 @@ function xows_wrtc_set_local_stream(rpc, stream)
 
     // Request to create an SDP Answer
     rpc.createAnswer().then((rsd) => rpc.setLocalDescription(rsd))
+                      .then(() => {
+                        // Fallback timeout for answer ICE gathering
+                        setTimeout(() => {
+                          if(rpc.iceGatheringState !== "complete") {
+                            xows_log(1,"wrtc_local_stream","ICE gathering timeout (answer), forcing SDP delivery");
+                            xows_wrtc_sdp_deliver(rpc);
+                          }
+                        }, 5000);
+                      })
                       .then(null, (err) => xows_wrtc_onerror(rpc, err));
   }
 

--- a/xows_xmp.js
+++ b/xows_xmp.js
@@ -123,6 +123,7 @@ function xows_xmp_set_callback(event, callback)
     case "mucsubj":   xows_xmp_fw_muc_onsubj = callback; break;
     case "mucnoti":   xows_xmp_fw_muc_onnoti = callback; break;
     case "jingrecv":  xows_xmp_fw_jing_onecv = callback; break;
+    case "jmsgrecv":  xows_xmp_fw_jmsg_onrecv = callback; break;
     case "error":     xows_xmp_fw_onerror = callback; break;
   }
 }
@@ -1659,6 +1660,17 @@ function xows_xmp_message_recv(stanza)
         */
       }
       continue;
+    }
+
+    // Check for Jingle Message Initiation (XEP-0353)
+    if(xmlns === XOWS_NS_JINGLE_MSG || xmlns === "urn:xmpp:jingle-message:1") {
+      const medias = [];
+      const descs = node.querySelectorAll("description");
+      for(let j = 0; j < descs.length; ++j)
+        medias.push(descs[j].getAttribute("media"));
+      xows_log(2,"xmp_message_recv","JMI message:",tname,"xmlns="+xmlns,"id="+node.getAttribute("id"),"from="+from);
+      xows_xmp_fw_jmsg_onrecv(from, tname, node.getAttribute("id"), medias);
+      return true;
     }
 
     // Check for chat state notification
@@ -4693,11 +4705,17 @@ const XOWS_NS_JINGLE_DTLS  = "urn:xmpp:jingle:apps:dtls:0";           //< XEP-01
 const XOWS_NS_JINGLE_GRP   = "urn:xmpp:jingle:apps:grouping:0";       //< XEP-0166 / XEP-0338
 const XOWS_NS_JINGLE_SSMA  = "urn:xmpp:jingle:apps:rtp:ssma:0";       //< XEP-0166 / XEP-0339
 const XOWS_NS_JINGLE_RTPI  = "urn:xmpp:jingle:apps:rtp:info:1";       //< XEP-0167
+const XOWS_NS_JINGLE_MSG   = "urn:xmpp:jingle-message:0";             //< XEP-0353
 
 /**
  * Module Event-Forwarding callback for Received Jingle IQ
  */
 let xows_xmp_fw_jing_onecv = function() {};
+
+/**
+ * Module Event-Forwarding callback for Received Jingle Message (XEP-0353)
+ */
+let xows_xmp_fw_jmsg_onrecv = function() {};
 
 /* ---------------------------------------------------------------------------
  * Jingle - Session Description Protocol (SDP) conversions
@@ -4740,11 +4758,9 @@ function xows_xmp_jing_jingle2sdp(jingle)
     sdp += "\r\n";
   }
 
-  //a=msid-semantic:WMS *
-  // not implemented
-
-  //a=ice-options:trickle
-  // not handled by jingle
+  // Check for trickle ICE support (standard or Conversations-specific)
+  if(jingle.querySelector("trickle"))
+    sdp += "a=ice-options:trickle\r\n";
 
   // Medias infos from <content> nodes
   const content = jingle.querySelectorAll(":scope > content");
@@ -4756,7 +4772,7 @@ function xows_xmp_jing_jingle2sdp(jingle)
 
     //m=audio 9 UDP/TLS/RTP/SAVPF 109 9 0 8 101
     sdp += "m="+description.getAttribute("media");
-    sdp += fingerprints.length ? " 1 RTP/SAVPF" : " RTP/AVPF";
+    sdp += fingerprints.length ? " 9 UDP/TLS/RTP/SAVPF" : " 9 RTP/AVPF";
 
     const payload_type = description.querySelectorAll("payload-type");
     for(let j = 0; j < payload_type.length; ++j)
@@ -4770,12 +4786,12 @@ function xows_xmp_jing_jingle2sdp(jingle)
     const senders = transport.getAttribute("senders");
     switch(senders)
     {
-    case "both": sdp += "a=sendrecv"; break;
-    case "initiator": sdp += "a=sendonly"; break;
-    case "responder": sdp += "a=recvonly"; break;
-    case "none": sdp += "a=inactive"; break;
+    case "both": sdp += "a=sendrecv\r\n"; break;
+    case "initiator": sdp += "a=sendonly\r\n"; break;
+    case "responder": sdp += "a=recvonly\r\n"; break;
+    case "none": sdp += "a=inactive\r\n"; break;
+    default: sdp += "a=sendrecv\r\n"; break;
     }
-    sdp += "\r\n";
 
     //a=mid:0
     sdp += "a=mid:"+content[i].getAttribute("name")+"\r\n";
@@ -4805,13 +4821,25 @@ function xows_xmp_jing_jingle2sdp(jingle)
       sdp += " "+rtp_hdrext[j].getAttribute("uri")+"\r\n";
     }
 
+    //a=extmap-allow-mixed
+    if(description.querySelector("extmap-allow-mixed"))
+      sdp += "a=extmap-allow-mixed\r\n";
+
     //a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
     for(let j = 0; j < payload_type.length; ++j) {
       const parameter = payload_type[j].querySelectorAll("parameter");
       if(parameter.length) {
         sdp += "a=fmtp:"+payload_type[j].getAttribute("id")+" ";
         for(let k = 0; k < parameter.length; ++k) {
-          sdp += parameter[k].getAttribute("name")+"="+parameter[k].getAttribute("value");
+          const pname = parameter[k].getAttribute("name");
+          const pvalue = parameter[k].getAttribute("value");
+          if(pname && pvalue) {
+            sdp += pname+"="+pvalue;
+          } else if(pname) {
+            sdp += pname;
+          } else if(pvalue) {
+            sdp += pvalue;
+          }
           if(k < (parameter.length - 1)) sdp += ";";
         }
         sdp += "\r\n";
@@ -4848,13 +4876,11 @@ function xows_xmp_jing_jingle2sdp(jingle)
     }
 
     //a=ssrc:1815119038 cname:{082af9fe-ac02-43d5-b5b6-069a14fa999f}
-    const source = description.querySelectorAll("source");
+    const source = description.querySelectorAll(":scope > source");
     for(let j = 0; j < source.length; ++j) {
-      sdp += "a=ssrc:"+source[j].getAttribute("ssrc");
-      const parameter = source[j].querySelector("parameter");
-      if(parameter)
-        sdp += " "+parameter.getAttribute("name")+":"+parameter.getAttribute("value");
-      sdp += "\r\n";
+      const params = source[j].querySelectorAll("parameter");
+      for(let k = 0; k < params.length; ++k)
+        sdp += "a=ssrc:"+source[j].getAttribute("ssrc")+" "+params[k].getAttribute("name")+":"+params[k].getAttribute("value")+"\r\n";
     }
 
     //a=ssrc-group:FID 1815119038 3975978373
@@ -4940,8 +4966,17 @@ function xows_xmp_jing_sdp2jingle(sdp)
         const payload_type = description.querySelector("payload-type[id='"+fmt[j].payload+"']");
         if(payload_type) {
           for(let k = 0; k < fmt[j].config.length; ++k) {
-            const param = fmt[j].config[k].split('=');
-            xows_xml_parent(payload_type, xows_xml_node("parameter",{"name":param[0],"value":param[1]}));
+            const eqIdx = fmt[j].config[k].indexOf('=');
+            let pname, pvalue;
+            if(eqIdx !== -1) {
+              pname = fmt[j].config[k].substring(0, eqIdx);
+              pvalue = fmt[j].config[k].substring(eqIdx + 1);
+            } else {
+              // No key=value format (e.g. RED codec "111/111") — use whole string as value
+              pname = "";
+              pvalue = fmt[j].config[k];
+            }
+            xows_xml_parent(payload_type, xows_xml_node("parameter",{"name":pname,"value":pvalue}));
           }
         }
       }
@@ -4971,13 +5006,20 @@ function xows_xmp_jing_sdp2jingle(sdp)
       }
     }
 
-    // add <source> nodes
+    // add <source> nodes, grouping parameters by SSRC (XEP-0339)
     if(sdpjson.media[i].ssrc) {
       const ssrc = sdpjson.media[i].ssrc;
+      const ssrc_map = new Map();
       for(let j = 0; j < ssrc.length; ++j) {
-        // new <source> node with <parameter> into <description>
-        xows_xml_parent(description, xows_xml_node("source",{"xmlns":XOWS_NS_JINGLE_SSMA,"ssrc":ssrc[j].id},
-                                        xows_xml_node("parameter",{"name":ssrc[j].attribute,"value":ssrc[j].value})));
+        if(!ssrc_map.has(ssrc[j].id))
+          ssrc_map.set(ssrc[j].id, []);
+        ssrc_map.get(ssrc[j].id).push(ssrc[j]);
+      }
+      for(const [id, params] of ssrc_map) {
+        const source = xows_xml_node("source",{"xmlns":XOWS_NS_JINGLE_SSMA,"ssrc":id});
+        for(let j = 0; j < params.length; ++j)
+          xows_xml_parent(source, xows_xml_node("parameter",{"name":params[j].attribute,"value":params[j].value}));
+        xows_xml_parent(description, source);
       }
     }
 
@@ -5079,6 +5121,7 @@ function xows_xmp_jing_recv(stanza)
         xows_xmp_iq_error_send(id, from, "cancel", "bad-request");
         return;
       }
+      xows_log(2,"xmp_jing_recv","Generated SDP:\n"+data);
     } break;
 
   case "session-info": {
@@ -5086,6 +5129,35 @@ function xows_xmp_jing_recv(stanza)
       // otherwise this is a session ping
       if(jingle.childNodes.length)
         data = jingle.childNodes[0].tagName;
+    } break;
+
+  case "transport-info": {
+      // Extract ICE candidates from transport-info
+      const content = jingle.querySelector("content");
+      if(content) {
+        const transport = content.querySelector("transport");
+        if(transport) {
+          const candidates = transport.querySelectorAll("candidate");
+          const mid = content.getAttribute("name");
+          const ufrag = transport.getAttribute("ufrag");
+          data = [];
+          for(let i = 0; i < candidates.length; ++i) {
+            const c = candidates[i];
+            let candstr = "candidate:"+c.getAttribute("foundation")
+                        +" "+c.getAttribute("component")
+                        +" "+c.getAttribute("protocol").toUpperCase()
+                        +" "+c.getAttribute("priority")
+                        +" "+c.getAttribute("ip")
+                        +" "+c.getAttribute("port")
+                        +" typ "+c.getAttribute("type");
+            if(c.hasAttribute("rel-addr")) candstr += " raddr "+c.getAttribute("rel-addr");
+            if(c.hasAttribute("rel-port")) candstr += " rport "+c.getAttribute("rel-port");
+            if(c.hasAttribute("generation")) candstr += " generation "+c.getAttribute("generation");
+            if(ufrag) candstr += " ufrag "+ufrag;
+            data.push({"candidate":candstr,"sdpMid":mid,"sdpMLineIndex":0});
+          }
+        }
+      }
     } break;
   }
 
@@ -5130,14 +5202,15 @@ function xows_xmp_jing_parse(stanza, onparse)
  * @parma   {string}    to          Destination JID
  * @parma   {string}    sdp         SDP offer string
  * @param   {function} [onparse]    Optional callback to receive query result
+ * @param   {string}   [sid]        Optional session ID (reuse JMI sid)
  *
  * @return  {string}    Initiated Jingle session ID
  */
-function xows_xmp_jing_initiate_sdp(to, sdp, onparse)
+function xows_xmp_jing_initiate_sdp(to, sdp, onparse, sid)
 {
   // Create <jingle> RTP session from SDP string
   const jingle = xows_xmp_jing_sdp2jingle(sdp);
-  const sid = xows_gen_nonce_asc(16); // xows_sdp_get_sid(sdp);
+  if(!sid) sid = xows_gen_nonce_asc(16);
 
   // Complete <jingle> node with proper attributes
   jingle.setAttribute("initiator",xows_xmp_bind.jful);
@@ -5240,6 +5313,73 @@ function xows_xmp_jing_error(id, to, type, condjing, condxmpp)
 }
 
 /* ---------------------------------------------------------------------------
+ * Jingle Message Initiation (XEP-0353) - Send functions
+ * ---------------------------------------------------------------------------*/
+/**
+ * Sends a Jingle Message Initiation <propose> message.
+ *
+ * @parma   {string}    to          Destination bare JID
+ * @parma   {string}    sid         Jingle session ID
+ * @parma   {string[]}  medias      Array of media types (e.g. ["audio","video"])
+ */
+function xows_xmp_jmsg_propose_send(to, sid, medias)
+{
+  const descs = [];
+  for(let i = 0; i < medias.length; ++i)
+    descs.push(xows_xml_node("description",{"xmlns":XOWS_NS_JINGLE_RTP1,"media":medias[i]}));
+  xows_xmp_send(xows_xml_node("message",{"to":to,"type":"chat"},
+                  xows_xml_node("propose",{"xmlns":XOWS_NS_JINGLE_MSG,"id":sid}, descs)));
+}
+
+/**
+ * Sends a Jingle Message Initiation <retract> message.
+ *
+ * @parma   {string}    to          Destination bare JID
+ * @parma   {string}    sid         Jingle session ID
+ */
+function xows_xmp_jmsg_retract_send(to, sid)
+{
+  xows_xmp_send(xows_xml_node("message",{"to":to,"type":"chat"},
+                  xows_xml_node("retract",{"xmlns":XOWS_NS_JINGLE_MSG,"id":sid})));
+}
+
+/**
+ * Sends a Jingle Message Initiation <proceed> message.
+ *
+ * @parma   {string}    to          Destination JID
+ * @parma   {string}    sid         Jingle session ID
+ */
+function xows_xmp_jmsg_proceed_send(to, sid)
+{
+  xows_xmp_send(xows_xml_node("message",{"to":to},
+                  xows_xml_node("proceed",{"xmlns":XOWS_NS_JINGLE_MSG,"id":sid})));
+}
+
+/**
+ * Sends a Jingle Message Initiation <reject> message.
+ *
+ * @parma   {string}    to          Destination JID
+ * @parma   {string}    sid         Jingle session ID
+ */
+function xows_xmp_jmsg_reject_send(to, sid)
+{
+  xows_xmp_send(xows_xml_node("message",{"to":to},
+                  xows_xml_node("reject",{"xmlns":XOWS_NS_JINGLE_MSG,"id":sid})));
+}
+
+/**
+ * Sends a Jingle Message Initiation <ringing> message.
+ *
+ * @parma   {string}    to          Destination JID
+ * @parma   {string}    sid         Jingle session ID
+ */
+function xows_xmp_jmsg_ringing_send(to, sid)
+{
+  xows_xmp_send(xows_xml_node("message",{"to":to},
+                  xows_xml_node("ringing",{"xmlns":XOWS_NS_JINGLE_MSG,"id":sid})));
+}
+
+/* ---------------------------------------------------------------------------
  *
  * XMPP API - Entity Capabilities (XEP-0115)
  *
@@ -5295,7 +5435,8 @@ function xows_xmp_caps_self_features()
     xows_xml_node("feature",{"var":XOWS_NS_JINGLE}),
     xows_xml_node("feature",{"var":XOWS_NS_JINGLE_RTP1}),
     xows_xml_node("feature",{"var":XOWS_NS_JINGLE_RTPA}),
-    xows_xml_node("feature",{"var":XOWS_NS_JINGLE_RTPV})
+    xows_xml_node("feature",{"var":XOWS_NS_JINGLE_RTPV}),
+    xows_xml_node("feature",{"var":XOWS_NS_JINGLE_MSG})
   ];
 
   return caps;


### PR DESCRIPTION
# Audio/Video Call Fixes

## Summary

Fixed audio and video calls between xows and multiple XMPP clients: Conversations (Android), Monal (iOS), and Siskin IM (iOS). Both outbound and inbound calls now work for audio and video.

## Changes by file

### xows_wrtc.js — WebRTC module

- **ICE candidate errors no longer kill the call.** The original code treated every `onicecandidateerror` (e.g. STUN DNS failure on one interface) as fatal and immediately terminated the call. These errors are normal — only `connectionState === "failed"` means the connection truly failed.

- **Fixed TURN credential generation.** `xows_hmac_sha1(username, secret)` had the arguments swapped. The TURN REST API spec requires `HMAC-SHA1(key=secret, data=username)`. This caused 401 errors and no relay candidates.

- **Added `onicecandidate` handler.** The `onicegatheringstatechange` event is unreliable in some browsers. The `onicecandidate` with `null` candidate is a more dependable signal that gathering is done.

- **Added 5-second ICE gathering timeout.** If ICE gathering never reaches "complete" (e.g. some STUN probes hang on unreachable interfaces), the SDP is sent with whatever candidates were gathered.

- **Added `sdp_sent` guard.** Prevents duplicate SDP delivery from multiple completion signals (state change, null candidate, timeout).

- **Fixed ICE server URL construction.** The URL was built as `type:host:port` without the `?transport=` parameter. TURN over TCP/TLS requires `?transport=tcp` in the URL — without it, the browser only tries UDP, which fails on restricted networks. Also added a guard for missing port to avoid `stun:host:undefined`. The `?transport=` parameter is only appended for TURN/TURNS URLs (not STUN, which doesn't support it).

### xows_xmp.js — XMPP protocol module

- **Added Jingle Message Initiation (XEP-0353) support.** Conversations and Monal send `<propose>` before `<session-initiate>`. Without handling this, incoming calls were logged as "unhandled message" and ignored. Added parsing of `propose`, `proceed`, `retract`, `reject`, `accept`, `ringing`, `finish` messages in the `urn:xmpp:jingle-message:0` namespace, plus send functions for `propose`, `proceed`, `reject`, `retract`, and `ringing`.

- **Advertised JMI in entity capabilities.** Added `urn:xmpp:jingle-message:0` to disco features so other clients discover JMI support. Also accepts `urn:xmpp:jingle-message:1` namespace for compatibility.

- **Fixed SDP m-line generation.** Changed `m=audio 1 RTP/SAVPF` to `m=audio 9 UDP/TLS/RTP/SAVPF` — correct port and protocol string for WebRTC with DTLS-SRTP.

- **Fixed empty SDP line when `senders` is null.** Conversations doesn't set the `senders` attribute on `<transport>`, so the direction switch fell through and produced a bare `\r\n` (invalid SDP). Now defaults to `a=sendrecv`.

- **Fixed SSRC source selector.** `querySelectorAll("source")` also matched `<source>` elements nested inside `<ssrc-group>` (which have no parameters), producing invalid bare `a=ssrc:` lines. Changed to `:scope > source`.

- **Fixed SSRC parameter output.** Only the first `<parameter>` per `<source>` was emitted. Now all parameters are output (e.g. both `cname` and `msid`).

- **Fixed fmtp parameter parsing (SDP→Jingle).** SDP lines like `a=fmtp:63 111/111` (RED codec) aren't `key=value` pairs. The code split on `=` and passed `undefined` as the value. Now uses `indexOf('=')` and handles valueless fmtp entries correctly.

- **Fixed fmtp parameter output (Jingle→SDP).** Parameters with name but no value (e.g. Monal's `<parameter name="111/111"/>`) produced `111/111=null`. Now handles all combinations: name+value → `name=value`, name only → `name`, value only → `value`.

- **Fixed SSRC source grouping (SDP→Jingle).** Multiple SDP `a=ssrc:` lines for the same SSRC were creating separate `<source>` XML elements instead of grouping parameters under one. Per XEP-0339, all parameters for the same SSRC must be under a single `<source>` element. Strict clients like Monal rejected the malformed Jingle.

- **Added `extmap-allow-mixed` output.** Conversations sends this attribute; now reflected in generated SDP.

- **Added `a=ice-options:trickle` output.** Emitted when the Jingle stanza contains a `<trickle>` element.

- **Added `transport-info` handling.** Conversations and Monal use trickle ICE — they send candidates separately after `session-initiate`. Previously these were completely unhandled. Now parsed into `RTCIceCandidate` objects and added to the peer connection.

- **Added ICE candidate queueing.** Trickle ICE candidates arriving before `setRemoteDescription` completes caused `addIceCandidate` to fail. Candidates are now queued in `sess.ice_queue` and flushed after the remote description is set.

- **Added debug SDP log.** Logs the generated SDP on `session-initiate` / `session-accept` for easier debugging.

### xows_cli.js — Client module

- **Added JMI session lifecycle.** New `xows_cli_call_jmsg_onrecv` handler processes `propose` (create ringing session), `retract` (caller cancelled), `accept` (another device picked up), `finish` (call ended). On user accept, sends `<proceed>` and waits for `session-initiate`. On user decline, sends `<reject>`.

- **Added outbound JMI propose flow.** Outgoing calls now send `<propose>` first (required by iOS clients like Monal and Conversations for push notifications/CallKit). On `<proceed>` from the peer, the Jingle `session-initiate` is sent with the same SID. If no JMI response within 10 seconds, falls back to direct `session-initiate` for non-JMI clients (e.g. Siskin IM).

- **Fixed SID mismatch between JMI and Jingle.** `xows_xmp_jing_initiate_sdp` always generated a new SID, ignoring the one from the JMI `propose`. The remote client rejected the `session-initiate` because the SID didn't match. Now the existing SID is reused when available.

- **Added `jmi` field to call session.** Tracks whether a session was initiated via JMI and stores proposed media types (audio/video) for use before SDP is available.

- **Added `ice_queue` to call session.** Buffers trickle ICE candidates that arrive before `setRemoteDescription` completes. Flushed after remote SDP is set in all paths (direct invite, JMI session-initiate, session-accept).

- **Modified `xows_cli_call_medias` for JMI.** Falls back to JMI media info when no SDP or stream is available yet.

- **Modified session-initiate handling for JMI.** When a JMI session already exists (user already accepted), `session-initiate` updates the session with remote SDP instead of creating a new one.

- **Auto-accept on `ontrack` for JMI.** When the user already accepted via JMI and the remote stream arrives, automatically sets the local stream and creates the SDP answer. Each track arrival is forwarded to the GUI so it can upgrade from audio to video when the video track arrives.

- **Detect `connectionState === "failed"`.** Added proper handling in `xows_cli_wrtc_onstate` to terminate the call when the RTC connection fails.

- **Added 30-second call timeout.** If the peer doesn't respond to `session-initiate` within 30 seconds, the call is terminated with "No answer from the other party".

### xows_gui_call.js — GUI module

- **Handle null stream in `xows_gui_call_onoffer`.** JMI `propose` has no media stream yet (it arrives later with `session-initiate`). The GUI now shows the ringing dialog without trying to add a null stream to the call view.

- **Audio-to-video element upgrade.** When the first `ontrack` fires with only audio, the GUI creates an `<audio>` element. When the video track arrives later on the same stream, the old `<strm-audio>` wrapper is removed and replaced with a `<strm-video>` + `<video>` element.

- **Guard against audio-less streams in `xows_snd_outpt_new`.** Video-only streams (e.g. first track from Monal video call) crashed `createMediaStreamSource` because there were no audio tracks. Audio output is now only created when the stream has audio tracks.

- **Added "timeout" reason to ringing dialog.** Shows "No answer from the other party" when call times out.
